### PR TITLE
占空比为50%的分频电路

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,107 @@
 # -
 占空比50%的三分频电路
+// Code your design here
+// Module Function:任意整数时钟分频
+ 
+module divide (	clk,rst_n,clkout);
+ 
+        input 	clk,rst_n;                     
+        output	clkout;                        
+ 
+        //parameter是verilog里常数语句
+	parameter	WIDTH	= 3;   //计数器的位数，计数的最大值为 2**WIDTH-1
+	parameter	N	= 4;    //分频系数，请确保 N < 2**WIDTH-1，否则计数会溢出
+ 
+	reg [WIDTH-1:0]	cnt_p,cnt_n; //cnt_p为上升沿触发时的计数器，cnt_n为下降沿触发时的计数器
+	reg	 clk_p,clk_n;//clk_p为上升沿触发时分频时钟，clk_n为下降沿触发时分频时钟
+ 
+	//上升沿触发时计数器的控制
+	always @ (posedge clk or negedge rst_n )  //posedge和negedge是verilog表示信号上升沿和下降沿
+  //当clk上升沿来临或者rst_n变低的时候执行一次always里的语句
+		begin
+			if(!rst_n)
+				cnt_p<=0;
+			else if (cnt_p==(N-1))
+				cnt_p<=0;
+			else cnt_p<=cnt_p+1; //计数器一直计数，当计数到N-1的时候清零，这是一个模N的计数器
+		end
+ 
+//上升沿触发的分频时钟输出,如果N为奇数得到的时钟占空比不是50%；如果N为偶数得到的时钟占空比为50%
+         always @ (posedge clk or negedge rst_n)
+		begin
+			if(!rst_n)
+				clk_p<=0;
+			else if (cnt_p<(N>>1)) //N>>1表示右移一位，相当于除以2去掉余数
+				clk_p<=0;
+			else 
+				clk_p<=1;    //得到的分频时钟正周期比负周期多一个clk时钟
+		end
+ 
+        //下降沿触发时计数器的控制        	
+	always @ (negedge clk or negedge rst_n)
+		begin
+			if(!rst_n)
+				cnt_n<=0;
+			else if (cnt_n==(N-1))
+				cnt_n<=0;
+			else cnt_n<=cnt_n+1;
+		end
+ 
+        //下降沿触发的分频时钟输出，和clk_p相差半个时钟
+	always @ (negedge clk)
+		begin
+			if(!rst_n)
+				clk_n<=0;
+			else if (cnt_n<(N>>1))  
+				clk_n<=0;
+			else 
+				clk_n<=1;  //得到的分频时钟正周期比负周期多一个clk时钟
+		end
+ 
+        assign clkout = (N==1)?clk:(N[0])?(clk_p&clk_n):clk_p;   //条件判断表达式
+                      //当N=1时，直接输出clk
+                       //当N为偶数也就是N的最低位为0，N（0）=0，输出clk_p
+                       //当N为奇数也就是N最低位为1，N（0）=1，输出clk_p&clk_n。正周期多所以是相与
+endmodule     
+
+
+#########################################
+#########################################
+// Code your testbench here
+// or browse Examples
+
+`timescale 1ns/100ps     
+ 
+module divide_tb();  
+ 
+reg    clk,rst_n; 
+wire   clkout;    
+ 
+//初始化过程块
+initial 
+begin 
+	 clk = 0;
+	rst_n = 0;
+	#25     //#表示延时25个时间单位
+	rst_n = 1;    
+end
+ 
+   always #10 clk = ~clk;     
+ 
+//module调用例化格式
+  divide  #(.WIDTH(3),.N(3))  u1 (                        
+                                                      
+		.clk	(clk),    
+		.rst_n	(rst_n),   
+		.clkout	(clkout)   
+					  );
+  
+   initial begin
+    $dumpfile("divide_tb.vcd");
+    $dumpvars();
+  end
+  
+    initial
+  #2000 $finish;
+  
+endmodule


### PR DESCRIPTION
1，偶数分频：偶数倍分频相对简单，比较容易理解。通过计数器计数是完全可以实现的。如进行N倍偶数分频，那么通过时钟触发计数器计数，当计数器从0计数到N/2-1时，输出时钟进行翻转，以此循环下去。
2，奇数分频： 如果要实现占空比为50%的奇数倍分频，不能同偶数分频一样计数器记到一半的时候输出时钟翻转，那样得不到占空比50%的时钟。以待分频时钟CLK为例，如果以偶数分频的方法来做奇数分频，在CLK上升沿触发，将得到不是50%占空比的一个时钟信号（正周期比负周期多一个时钟或者少一个时钟）；但是如果在CLK下降沿也触发，又得到另外一个不是50%占空比的时钟信号，这两个时钟相位正好相差半个CLK时钟周期。通过这两个时钟信号进行逻辑运算我们可以巧妙的得到50%占空比的时钟。 
总结如下：对于实现占空比为50%的N倍奇数分频，首先进行上升沿触发进行模N计数，计数选定到某一个值进行输出时钟翻转，然后经过（N-1）/2再次进行翻转得到一个占空比非50%奇数n分频时钟。再者同时进行下降沿触发的模N计数，到和上升沿触发输出时钟翻转选定值相同值时，进行输出时钟时钟翻转，同样经过（N-1）/2时，输出时钟再次翻转生成占空比非50%的奇数n分频时钟。两个占空比非50%的n分频时钟进行逻辑运算（正周期多的相与，负周期多的相或），得到占空比为50%的奇数n分频时钟。